### PR TITLE
fix(TD-0006): Add time display with browser-local timezone

### DIFF
--- a/src/app/dashboard/tickets/[id]/page.tsx
+++ b/src/app/dashboard/tickets/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react"
 import { useParams, useRouter } from "next/navigation"
 import Link from "next/link"
-import { ArrowLeft, ExternalLink, Flag } from "lucide-react"
+import { ArrowLeft, ExternalLink, Flag, Clock } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Select } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
@@ -11,6 +11,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { PipelineProgress } from "@/components/pipeline-progress"
 import { TicketStatusBadge } from "@/components/ticket-status-badge"
 import { Timeline } from "@/components/timeline"
+import { LocalDateTime } from "@/components/local-date-time"
 import { STATUS_ORDER } from "@/lib/constants"
 import type { TicketStatus, TimelineEventPublic } from "@/types"
 
@@ -145,6 +146,17 @@ export default function TicketDetailPage() {
           <p className="text-sm text-gray-500 mt-1">
             {ticket.product.name} &middot; {ticket.submitterEmail}
             {ticket.submitterName && ` (${ticket.submitterName})`}
+          </p>
+          <p className="text-xs text-gray-400 mt-1 flex items-center gap-3">
+            <span className="flex items-center gap-1">
+              <Clock className="w-3 h-3" />
+              Created: <LocalDateTime value={ticket.createdAt} />
+            </span>
+            {ticket.updatedAt !== ticket.createdAt && (
+              <span className="flex items-center gap-1">
+                Updated: <LocalDateTime value={ticket.updatedAt} />
+              </span>
+            )}
           </p>
         </div>
         <Button variant="ghost" size="sm" onClick={toggleFlag}>

--- a/src/app/ticket/[publicId]/page.tsx
+++ b/src/app/ticket/[publicId]/page.tsx
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma"
 import { PipelineProgress } from "@/components/pipeline-progress"
 import { TicketStatusBadge } from "@/components/ticket-status-badge"
 import { Timeline } from "@/components/timeline"
+import { LocalDateTime } from "@/components/local-date-time"
 
 interface PageProps {
   params: { publicId: string }
@@ -55,7 +56,7 @@ export default async function PublicTicketPage({ params }: PageProps) {
 
         <h1 className="text-2xl font-bold text-gray-900 mb-1">{ticket.subject}</h1>
         <p className="text-sm text-gray-500 mb-6">
-          {ticket.product.name} &middot; Submitted {new Date(ticket.createdAt).toLocaleDateString()}
+          {ticket.product.name} &middot; Submitted <LocalDateTime value={ticket.createdAt.toISOString()} />
         </p>
 
         {/* Pipeline Progress */}

--- a/src/components/local-date-time.tsx
+++ b/src/components/local-date-time.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+/**
+ * LocalDateTime - renders an ISO timestamp in the user's browser local timezone.
+ *
+ * Use this component in server component trees where you can't call
+ * toLocaleString() directly (server timezone ≠ user timezone).
+ */
+interface LocalDateTimeProps {
+  value: string | Date
+  dateStyle?: Intl.DateTimeFormatOptions["dateStyle"]
+  timeStyle?: Intl.DateTimeFormatOptions["timeStyle"]
+  className?: string
+}
+
+export function LocalDateTime({
+  value,
+  dateStyle = "medium",
+  timeStyle = "short",
+  className,
+}: LocalDateTimeProps) {
+  const formatted = new Date(value).toLocaleString(undefined, {
+    dateStyle,
+    timeStyle,
+  })
+  return <span className={className}>{formatted}</span>
+}

--- a/src/components/ticket-table.tsx
+++ b/src/components/ticket-table.tsx
@@ -43,7 +43,10 @@ export function TicketTable({ tickets }: TicketTableProps) {
                 <TicketStatusBadge status={ticket.status} />
               </td>
               <td className="py-3 text-gray-400 text-xs hidden lg:table-cell">
-                {new Date(ticket.createdAt).toLocaleDateString()}
+                {new Date(ticket.createdAt).toLocaleString(undefined, {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                })}
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary

Adds time display to the tickets dashboard and ensures all timestamps render in the user's browser local timezone.

Closes #4

## Changes

### New: `LocalDateTime` client component
A reusable `"use client"` component that accepts an ISO timestamp and renders it using `toLocaleString()` in the browser's local timezone. Safe to use from both client and server component trees.

### `ticket-table.tsx`
- Changed `toLocaleDateString()` → `toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })`
- Date column now shows e.g. `Mar 14, 2026, 11:29 AM` instead of `3/14/2026`

### `ticket/[publicId]/page.tsx` (public ticket page)
- Replaced `toLocaleDateString()` with `<LocalDateTime>` component
- **Bug fix:** this is a server component, so `toLocaleDateString()` was using the _server's_ timezone. Now correctly uses the browser's local timezone.

### `dashboard/tickets/[id]/page.tsx` (ticket detail page)
- Added created/updated timestamps to the ticket metadata section (was missing entirely)
- Shows a clock icon with "Created:" and optionally "Updated:" times

## Format
`toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })` — e.g. `Mar 14, 2026, 11:29 AM`

Respects the user's locale and browser timezone automatically.