### PR TITLE
fix(TD-0005): update ticket status to MERGED when PR is merged

### DIFF
--- a/src/__tests__/api/webhooks-github.test.ts
+++ b/src/__tests__/api/webhooks-github.test.ts
@@ -70,6 +70,25 @@ describe("GitHub webhook handler logic", () => {
       })
       expect(status).toBeNull()
     })
+
+    // TD-0005: merged PR with no "Closes #N" in body should still map to MERGED
+    it("maps merged PR to MERGED even when body has no issue reference", () => {
+      const status = mapEventToStatus("pull_request", "closed", {
+        pull_request: { number: 10, merged: true, body: "chore: update deps" },
+      })
+      expect(status?.status).toBe("MERGED")
+    })
+
+    // TD-0005: extractIssueNumber returns null for PR bodies without issue refs
+    it("extractIssueNumber returns null for PR body without issue reference", () => {
+      expect(extractIssueNumber("chore: update deps\n\nTinyDesk-Ticket: TD-0005")).toBeNull()
+    })
+
+    // TD-0005: extractTicketId works on PR bodies with TinyDesk-Ticket references
+    it("extracts TinyDesk ticket ID from PR body as fallback lookup key", () => {
+      const body = "fix: some change\n\nTinyDesk-Ticket: TD-0005\nStatus page: https://example.com"
+      expect(extractTicketId(body)).toBe("TD-0005")
+    })
   })
 
   describe("review event processing", () => {

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -80,21 +80,10 @@ export async function POST(req: NextRequest) {
 
     // Handle PR events
     if (event === "pull_request") {
-      const issueNumber = extractIssueNumber(payload.pull_request?.body)
-      if (!issueNumber) {
-        return NextResponse.json({ ok: true, message: "No issue reference in PR" })
-      }
-
-      // Find ticket linked to this issue number for this product
-      const ticket = await prisma.ticket.findFirst({
-        where: {
-          productId: product.id,
-          issueNumber,
-        },
-      })
+      const ticket = await findTicketForPR(product.id, payload)
 
       if (!ticket) {
-        return NextResponse.json({ ok: true, message: "No ticket linked to this issue" })
+        return NextResponse.json({ ok: true, message: "No ticket linked to this PR" })
       }
 
       const statusMapping = mapEventToStatus(event, payload.action, payload)
@@ -102,7 +91,7 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ ok: true, message: "Unhandled action" })
       }
 
-      // Link PR to ticket
+      // Link PR to ticket on open
       if (payload.action === "opened") {
         await prisma.ticket.update({
           where: { id: ticket.id },
@@ -161,4 +150,53 @@ export async function POST(req: NextRequest) {
     console.error("[webhooks/github] Error:", error)
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
+}
+
+/**
+ * Find the TinyDesk ticket linked to an incoming pull_request webhook event.
+ *
+ * Strategy (in priority order):
+ *  1. By prNumber from the webhook payload — reliable for all actions because
+ *     prNumber is stored on the ticket when the PR is opened.
+ *  2. By issueNumber extracted from the PR body (e.g. "Closes #N") — covers
+ *     cases where the PR was opened before TinyDesk stored the prNumber.
+ *  3. By publicId extracted directly from the PR body
+ *     (e.g. "TinyDesk-Ticket: TD-XXXX") — covers PRs that reference the
+ *     ticket without going through a GitHub issue.
+ *
+ * This multi-strategy lookup fixes TD-0005: previously only strategy #2 was
+ * used, so a merged PR whose body lacked "Closes/Fixes/Resolves #N" would
+ * silently fail to update the ticket status.
+ */
+async function findTicketForPR(productId: string, payload: any) {
+  const prNumber: number | undefined = payload.pull_request?.number
+  const prBody: string | null = payload.pull_request?.body ?? null
+
+  // 1. Look up by prNumber stored on the ticket (most reliable path)
+  if (prNumber) {
+    const ticket = await prisma.ticket.findFirst({
+      where: { productId, prNumber },
+    })
+    if (ticket) return ticket
+  }
+
+  // 2. Look up by issueNumber extracted from PR body ("Closes #N")
+  const issueNumber = extractIssueNumber(prBody)
+  if (issueNumber) {
+    const ticket = await prisma.ticket.findFirst({
+      where: { productId, issueNumber },
+    })
+    if (ticket) return ticket
+  }
+
+  // 3. Look up by TinyDesk ticket ID embedded directly in PR body
+  const ticketPublicId = extractTicketId(prBody)
+  if (ticketPublicId) {
+    const ticket = await prisma.ticket.findFirst({
+      where: { productId, publicId: ticketPublicId },
+    })
+    if (ticket) return ticket
+  }
+
+  return null
 }


### PR DESCRIPTION
## Summary

Fixes a bug where merging a GitHub PR did not update the linked TinyDesk ticket status from `PR_OPEN` to `MERGED`.

Closes #3

## Root Cause

The `pull_request` webhook handler required the PR body to contain a `Closes/Fixes/Resolves #N` pattern to locate the linked ticket. When that pattern was absent — or the PR body was edited after opening — the merge event was silently discarded.

## Fix

Introduced a `findTicketForPR` helper that uses three lookup strategies in priority order:

1. **By `prNumber` from the webhook payload** _(new — most reliable)_  
   When a PR is opened, `prNumber` is stored on the ticket. On merge, the webhook payload always includes the PR number — no body parsing needed.

2. **By `issueNumber` extracted from PR body** (`Closes #N`) _(previous behaviour)_  
   Kept as a fallback for PRs opened before this fix was deployed.

3. **By TinyDesk ticket ID extracted from PR body** (`TinyDesk-Ticket: TD-XXXX`) _(new)_  
   Covers PRs that reference the ticket directly without a GitHub issue.

## Tests

Added unit tests covering:
- Merged PR with no issue reference in body still maps to `MERGED`
- `extractIssueNumber` returns `null` for bodies without `Closes/Fixes/Resolves`
- `extractTicketId` correctly reads `TinyDesk-Ticket: TD-XXXX` from PR bodies

All 77 tests pass.