### PR TITLE
[TD-0011] Add reissue ticket button on ticket detail page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1302,7 +1301,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -1797,7 +1795,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1815,7 +1812,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1876,7 +1872,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -2559,7 +2554,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2974,7 +2968,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3701,7 +3694,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3871,7 +3863,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5289,7 +5280,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6461,7 +6451,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6610,7 +6599,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6642,7 +6630,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -6719,7 +6706,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6732,7 +6718,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7778,7 +7763,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7867,7 +7851,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -8007,7 +7990,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8153,7 +8135,6 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",

--- a/src/__tests__/lib/tickets.test.ts
+++ b/src/__tests__/lib/tickets.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/prisma", () => ({
       count: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      findUnique: vi.fn(),
     },
     timelineEvent: {
       create: vi.fn(),
@@ -27,7 +28,7 @@ vi.mock("@/lib/github-app", () => ({
 }))
 
 import prisma from "@/lib/prisma"
-import { createTicket, updateTicketStatus, appendTimelineEvent } from "@/lib/tickets"
+import { createTicket, updateTicketStatus, appendTimelineEvent, reissueGitHubIssue } from "@/lib/tickets"
 import { sendTicketReceipt } from "@/lib/email"
 import { isGitHubAppConfigured } from "@/lib/github-app"
 
@@ -398,5 +399,73 @@ describe("appendTimelineEvent", () => {
         data: expect.objectContaining({ public: false }),
       })
     )
+  })
+})
+
+describe("reissueGitHubIssue", () => {
+  const baseTicket = {
+    id: "ticket-reissue",
+    publicId: "TD-0012",
+    subject: "Reissue test",
+    body: "Body",
+    screenshots: [],
+    submitterEmail: "user@example.com",
+    product: { repoOwner: "zenithventure", repoName: "tinydesk", defaultAssignee: null },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns alreadyExists=true and skips creation when issueUrl is already set", async () => {
+    const ticket = { ...baseTicket, issueUrl: "https://github.com/zenithventure/tinydesk/issues/99" }
+    const result = await reissueGitHubIssue(ticket)
+
+    expect(result.alreadyExists).toBe(true)
+    expect(result.issueUrl).toBe("https://github.com/zenithventure/tinydesk/issues/99")
+
+    const { createGitHubIssue } = await import("@/lib/github-app")
+    expect(createGitHubIssue).not.toHaveBeenCalled()
+  })
+
+  it("creates a GitHub issue and returns issueUrl when none exists", async () => {
+    vi.mocked(isGitHubAppConfigured).mockReturnValue(true)
+    vi.mocked(prisma.ticket.update).mockResolvedValue({} as any)
+    vi.mocked(prisma.ticket.findUnique).mockResolvedValue({
+      issueUrl: "https://github.com/zenithventure/tinydesk/issues/50",
+    } as any)
+    vi.mocked(prisma.timelineEvent.create).mockResolvedValue({} as any)
+
+    const { createGitHubIssue } = await import("@/lib/github-app")
+    vi.mocked(createGitHubIssue).mockResolvedValue({
+      number: 50,
+      html_url: "https://github.com/zenithventure/tinydesk/issues/50",
+    })
+
+    const result = await reissueGitHubIssue({ ...baseTicket, issueUrl: null })
+
+    expect(result.alreadyExists).toBe(false)
+    expect(result.issueUrl).toBe("https://github.com/zenithventure/tinydesk/issues/50")
+    expect(createGitHubIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: "zenithventure",
+        repo: "tinydesk",
+        title: "[TD-0012] Reissue test",
+      })
+    )
+  })
+
+  it("returns issueUrl=undefined when GitHub issue creation fails", async () => {
+    vi.mocked(isGitHubAppConfigured).mockReturnValue(true)
+    vi.mocked(prisma.ticket.findUnique).mockResolvedValue({ issueUrl: null } as any)
+    vi.mocked(prisma.timelineEvent.create).mockResolvedValue({} as any)
+
+    const { createGitHubIssue } = await import("@/lib/github-app")
+    vi.mocked(createGitHubIssue).mockRejectedValue(new Error("GitHub API down"))
+
+    const result = await reissueGitHubIssue({ ...baseTicket, issueUrl: null })
+
+    expect(result.alreadyExists).toBe(false)
+    expect(result.issueUrl).toBeUndefined()
   })
 })

--- a/src/app/api/dashboard/tickets/[id]/reissue/route.ts
+++ b/src/app/api/dashboard/tickets/[id]/reissue/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server"
+import prisma from "@/lib/prisma"
+import { requireAdmin } from "@/lib/auth"
+import { isGitHubAppConfigured } from "@/lib/github-app"
+import { reissueGitHubIssue } from "@/lib/tickets"
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const admin = await requireAdmin()
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const ticket = await prisma.ticket.findUnique({
+    where: { id: params.id },
+    include: { product: { select: { repoOwner: true, repoName: true, defaultAssignee: true } } },
+  })
+
+  if (!ticket) {
+    return NextResponse.json({ error: "Ticket not found" }, { status: 404 })
+  }
+
+  if (!ticket.product.repoOwner || !ticket.product.repoName) {
+    return NextResponse.json(
+      { error: "This product does not have a linked GitHub repository" },
+      { status: 422 }
+    )
+  }
+
+  if (!isGitHubAppConfigured()) {
+    return NextResponse.json(
+      { error: "GitHub App is not configured on this installation" },
+      { status: 422 }
+    )
+  }
+
+  try {
+    const result = await reissueGitHubIssue(ticket)
+
+    if (result.alreadyExists) {
+      return NextResponse.json(
+        { message: "A GitHub issue is already linked to this ticket", issueUrl: result.issueUrl },
+        { status: 200 }
+      )
+    }
+
+    if (!result.issueUrl) {
+      return NextResponse.json(
+        { error: "GitHub issue creation failed — check server logs for details" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ message: "GitHub issue created", issueUrl: result.issueUrl }, { status: 201 })
+  } catch (error) {
+    console.error("[dashboard/tickets/reissue] Error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/tickets/[id]/page.tsx
+++ b/src/app/dashboard/tickets/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react"
 import { useParams, useRouter } from "next/navigation"
 import Link from "next/link"
-import { ArrowLeft, ExternalLink, Flag, Clock } from "lucide-react"
+import { ArrowLeft, ExternalLink, Flag, Clock, RefreshCw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Select } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
@@ -51,6 +51,8 @@ export default function TicketDetailPage() {
   const [updating, setUpdating] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const [reissuing, setReissuing] = useState(false)
+  const [reissueMessage, setReissueMessage] = useState<{ type: "success" | "error"; text: string } | null>(null)
 
   const fetchData = useCallback(async (silent = false) => {
     if (silent) {
@@ -126,6 +128,27 @@ export default function TicketDetailPage() {
     }
   }
 
+  async function handleReissue() {
+    if (!ticket) return
+    setReissuing(true)
+    setReissueMessage(null)
+    try {
+      const res = await fetch(`/api/dashboard/tickets/${ticket.id}/reissue`, { method: "POST" })
+      const data = await res.json()
+      if (res.ok) {
+        setReissueMessage({ type: "success", text: data.message ?? "GitHub issue created" })
+        // Refresh ticket data to show the new issueUrl
+        await fetchData(true)
+      } else {
+        setReissueMessage({ type: "error", text: data.error ?? "Failed to reissue ticket" })
+      }
+    } catch {
+      setReissueMessage({ type: "error", text: "Network error — please try again" })
+    } finally {
+      setReissuing(false)
+    }
+  }
+
   if (loading) {
     return (
       <div className="space-y-4">
@@ -192,6 +215,24 @@ export default function TicketDetailPage() {
             disabled={updating}
           />
         </div>
+        {!ticket.issueUrl && (
+          <div className="flex flex-col items-end gap-1">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleReissue}
+              disabled={reissuing}
+            >
+              <RefreshCw className={`w-4 h-4 mr-1 ${reissuing ? "animate-spin" : ""}`} />
+              {reissuing ? "Creating…" : "Reissue Ticket"}
+            </Button>
+            {reissueMessage && (
+              <p className={`text-xs ${reissueMessage.type === "success" ? "text-emerald-600" : "text-red-500"}`}>
+                {reissueMessage.text}
+              </p>
+            )}
+          </div>
+        )}
         <Link
           href={`/ticket/${ticket.publicId}`}
           target="_blank"

--- a/src/lib/tickets.ts
+++ b/src/lib/tickets.ts
@@ -98,6 +98,31 @@ export async function updateTicketStatus(
   return ticket
 }
 
+/**
+ * Re-trigger GitHub issue creation for a ticket that missed it on initial
+ * creation (e.g. the GitHub App was not yet configured, or the API call
+ * failed transiently).  Safe to call multiple times — returns early if the
+ * ticket already has a linked issue.
+ */
+export async function reissueGitHubIssue(ticket: {
+  id: string
+  publicId: string
+  subject: string
+  body: string
+  screenshots: any
+  submitterEmail: string
+  issueUrl: string | null
+  product: { repoOwner: string | null; repoName: string | null; defaultAssignee: string | null }
+}): Promise<{ alreadyExists: boolean; issueUrl?: string }> {
+  if (ticket.issueUrl) {
+    // Issue already linked — don't create a duplicate
+    return { alreadyExists: true, issueUrl: ticket.issueUrl }
+  }
+  await autoCreateGitHubIssue(ticket)
+  const updated = await prisma.ticket.findUnique({ where: { id: ticket.id }, select: { issueUrl: true } })
+  return { alreadyExists: false, issueUrl: updated?.issueUrl ?? undefined }
+}
+
 async function autoCreateGitHubIssue(ticket: {
   id: string
   publicId: string


### PR DESCRIPTION
Closes #11

## What this does

When a ticket is received but the GitHub issue trigger failed (App not configured, transient API error, etc.), an admin can now click **"Reissue Ticket"** on the ticket detail page to manually trigger GitHub issue creation.

## Changes

### `src/lib/tickets.ts`
- Exported new `reissueGitHubIssue()` function — wraps `autoCreateGitHubIssue()` with a duplicate guard: if `ticket.issueUrl` is already set it returns `{ alreadyExists: true }` without calling the GitHub API.

### `src/app/api/dashboard/tickets/[id]/reissue/route.ts` (new)
- `POST` endpoint, admin-protected via `requireAdmin()`
- Returns `422` if product has no linked repo or GitHub App is not configured
- Returns `200 { alreadyExists: true }` if issue already linked
- Returns `201 { issueUrl }` on successful creation

### `src/app/dashboard/tickets/[id]/page.tsx`
- **Reissue Ticket** button added to the Actions bar — only rendered when `ticket.issueUrl` is null
- Shows spinner + "Creating…" label while in-flight
- Inline success (green) / error (red) message below the button
- On success, silently refreshes ticket data so the Links section + button visibility update immediately

### `src/__tests__/lib/tickets.test.ts`
- 3 new tests for `reissueGitHubIssue`: already-exists guard, happy path, failure handling

## Test results
83/83 tests passing ✅