### PR TITLE
fix: resolve auth crash and public ticket page errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",

--- a/prisma/migrations/0_init/migration.sql
+++ b/prisma/migrations/0_init/migration.sql
@@ -1,0 +1,160 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'VIEWER');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('RECEIVED', 'ISSUE_CREATED', 'FIX_IN_PROGRESS', 'PR_OPEN', 'CHANGES_REQUESTED', 'MERGED', 'DEPLOYED', 'CLOSED');
+
+-- CreateEnum
+CREATE TYPE "NotificationStatus" AS ENUM ('PENDING', 'SENT', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT NOT NULL,
+    "image" TEXT,
+    "role" "Role" NOT NULL DEFAULT 'VIEWER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "repoOwner" TEXT,
+    "repoName" TEXT,
+    "defaultAssignee" TEXT,
+    "supportEmail" TEXT,
+    "vercelProjectId" TEXT,
+    "webhookSecret" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProductOwner" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProductOwner_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" TEXT NOT NULL,
+    "publicId" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "submitterEmail" TEXT NOT NULL,
+    "submitterName" TEXT,
+    "subject" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "status" "TicketStatus" NOT NULL DEFAULT 'RECEIVED',
+    "issueNumber" INTEGER,
+    "issueUrl" TEXT,
+    "prNumber" INTEGER,
+    "prUrl" TEXT,
+    "releaseId" TEXT,
+    "releaseTag" TEXT,
+    "deploymentUrl" TEXT,
+    "deployedAt" TIMESTAMP(3),
+    "screenshots" JSONB,
+    "humanFlagged" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TimelineEvent" (
+    "id" TEXT NOT NULL,
+    "ticketId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "actor" TEXT,
+    "summary" TEXT NOT NULL,
+    "payload" JSONB,
+    "public" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TimelineEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "ticketId" TEXT NOT NULL,
+    "recipientEmail" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "status" "NotificationStatus" NOT NULL DEFAULT 'PENDING',
+    "sentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Product_slug_key" ON "Product"("slug");
+
+-- CreateIndex
+CREATE INDEX "ProductOwner_userId_idx" ON "ProductOwner"("userId");
+
+-- CreateIndex
+CREATE INDEX "ProductOwner_productId_idx" ON "ProductOwner"("productId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductOwner_userId_productId_key" ON "ProductOwner"("userId", "productId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_publicId_key" ON "Ticket"("publicId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_productId_idx" ON "Ticket"("productId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_status_idx" ON "Ticket"("status");
+
+-- CreateIndex
+CREATE INDEX "Ticket_submitterEmail_idx" ON "Ticket"("submitterEmail");
+
+-- CreateIndex
+CREATE INDEX "TimelineEvent_ticketId_idx" ON "TimelineEvent"("ticketId");
+
+-- CreateIndex
+CREATE INDEX "Notification_ticketId_idx" ON "Notification"("ticketId");
+
+-- AddForeignKey
+ALTER TABLE "ProductOwner" ADD CONSTRAINT "ProductOwner_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductOwner" ADD CONSTRAINT "ProductOwner_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TimelineEvent" ADD CONSTRAINT "TimelineEvent_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+┌─────────────────────────────────────────────────────────┐
+│  Update available 5.22.0 -> 7.5.0                       │
+│                                                         │
+│  This is a major update - please follow the guide at    │
+│  https://pris.ly/d/major-version-upgrade                │
+│                                                         │
+│  Run the following to update                            │
+│    npm i --save-dev prisma@latest                       │
+│    npm i @prisma/client@latest                          │
+└─────────────────────────────────────────────────────────┘

--- a/src/app/ticket/[publicId]/page.tsx
+++ b/src/app/ticket/[publicId]/page.tsx
@@ -119,7 +119,7 @@ export default function PublicTicketPage() {
 
         <h1 className="text-2xl font-bold text-gray-900 mb-1">{ticket.subject}</h1>
         <p className="text-sm text-gray-500 mb-6">
-          {ticket.product.name} &middot; Submitted <LocalDateTime value={ticket.createdAt.toISOString()} />
+          {ticket.productName} &middot; Submitted <LocalDateTime value={ticket.createdAt} />
         </p>
 
         {/* Pipeline Progress */}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -32,11 +32,17 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         token.role = user.role
 
         // Fetch the product IDs this user owns so we can gate visibility client-side.
-        const owned = await prisma.productOwner.findMany({
-          where: { userId: user.id },
-          select: { productId: true },
-        })
-        token.ownedProductIds = owned.map((o) => o.productId)
+        // Wrapped in try/catch: the ProductOwner table may not exist yet if the
+        // migration hasn't been applied (avoids crashing auth on older DB schemas).
+        try {
+          const owned = await prisma.productOwner.findMany({
+            where: { userId: user.id },
+            select: { productId: true },
+          })
+          token.ownedProductIds = owned.map((o) => o.productId)
+        } catch {
+          token.ownedProductIds = []
+        }
       }
       return token
     },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,11 +17,16 @@ export async function requireAdmin() {
  * Returns the product IDs that the given user owns.
  */
 export async function getOwnedProductIds(userId: string): Promise<string[]> {
-  const rows = await prisma.productOwner.findMany({
-    where: { userId },
-    select: { productId: true },
-  })
-  return rows.map((r) => r.productId)
+  try {
+    const rows = await prisma.productOwner.findMany({
+      where: { userId },
+      select: { productId: true },
+    })
+    return rows.map((r) => r.productId)
+  } catch {
+    // ProductOwner table may not exist yet if the migration hasn't been applied.
+    return []
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Auth crash**: `ProductOwner` queries in `src/auth.ts` and `src/lib/auth.ts` now gracefully return `[]` if the table doesn't exist yet, fixing the NextAuth `Configuration` error in production
- **Public ticket page**: Fixed `ticket.product.name` → `ticket.productName` and removed `.toISOString()` call on already-serialized string that caused runtime crash on `/ticket/[publicId]`
- **Auto-migrate on deploy**: Added `prisma migrate deploy` to the Vercel build script so future migrations run automatically
- **Baseline migration**: Added `0_init` migration so Prisma Migrate can track the existing production schema

## Test plan
- [ ] Verify auth/sign-in works on the Vercel preview deploy
- [ ] Verify public ticket page loads (e.g. `/ticket/TD-0013`)
- [ ] Verify dashboard loads for ADMIN and VIEWER roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)