### PR TITLE
fix: treat merged as final resolution state (TD-0014)

### DIFF
--- a/src/__tests__/lib/tickets.test.ts
+++ b/src/__tests__/lib/tickets.test.ts
@@ -352,6 +352,111 @@ describe("updateTicketStatus", () => {
       "PR merged"
     )
   })
+
+  // TD-0014: MERGED is the final resolution state
+  describe("TD-0014: auto-resolve on MERGED", () => {
+    it("auto-transitions to CLOSED when status reaches MERGED", async () => {
+      // Both MERGED and the subsequent CLOSED update will call prisma.ticket.update
+      vi.mocked(prisma.ticket.update).mockResolvedValue({
+        id: "ticket-merged",
+        publicId: "TD-0001",
+        submitterEmail: "user@example.com",
+        subject: "Bug fix",
+        status: "MERGED",
+        product: { name: "TinyCal" },
+      } as any)
+      vi.mocked(prisma.timelineEvent.create).mockResolvedValue({} as any)
+
+      await updateTicketStatus("ticket-merged", "MERGED", {
+        actor: "dev",
+        summary: "PR #42 merged",
+      })
+
+      // Should have called update twice: once for MERGED, once for the auto-close CLOSED
+      expect(prisma.ticket.update).toHaveBeenCalledTimes(2)
+      expect(prisma.ticket.update).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ data: expect.objectContaining({ status: "MERGED" }) })
+      )
+      expect(prisma.ticket.update).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ data: expect.objectContaining({ status: "CLOSED" }) })
+      )
+    })
+
+    it("sends exactly one email notification (for MERGED, not for the auto-close)", async () => {
+      vi.mocked(prisma.ticket.update).mockResolvedValue({
+        id: "ticket-merged",
+        publicId: "TD-0001",
+        submitterEmail: "user@example.com",
+        subject: "Bug fix",
+        status: "MERGED",
+        product: { name: "TinyCal" },
+      } as any)
+      vi.mocked(prisma.timelineEvent.create).mockResolvedValue({} as any)
+
+      await updateTicketStatus("ticket-merged", "MERGED", {
+        actor: "dev",
+        summary: "PR #42 merged",
+      })
+
+      const { sendStatusUpdate } = await import("@/lib/email")
+      // Only one email: for MERGED. The auto-close CLOSED transition is silent.
+      expect(sendStatusUpdate).toHaveBeenCalledTimes(1)
+      expect(sendStatusUpdate).toHaveBeenCalledWith(
+        "user@example.com",
+        "TD-0001",
+        "Bug fix",
+        "Merged",
+        "PR #42 merged"
+      )
+    })
+
+    it("records a timeline event for both MERGED and the auto-close CLOSED", async () => {
+      vi.mocked(prisma.ticket.update).mockResolvedValue({
+        id: "ticket-merged",
+        publicId: "TD-0001",
+        submitterEmail: "user@example.com",
+        subject: "Bug fix",
+        status: "MERGED",
+        product: { name: "TinyCal" },
+      } as any)
+      vi.mocked(prisma.timelineEvent.create).mockResolvedValue({} as any)
+
+      await updateTicketStatus("ticket-merged", "MERGED", {
+        actor: "dev",
+        summary: "PR #42 merged",
+      })
+
+      // Two timeline events: one for MERGED, one for auto-close CLOSED
+      expect(prisma.timelineEvent.create).toHaveBeenCalledTimes(2)
+      const summaries = vi
+        .mocked(prisma.timelineEvent.create)
+        .mock.calls.map((call) => call[0].data.summary)
+      expect(summaries).toContain("PR #42 merged")
+      expect(summaries).toContain("Ticket resolved: fix has been merged")
+    })
+
+    it("does NOT auto-close for non-MERGED status transitions", async () => {
+      vi.mocked(prisma.ticket.update).mockResolvedValue({
+        id: "ticket-1",
+        publicId: "TD-0001",
+        submitterEmail: "user@example.com",
+        subject: "Test",
+        status: "PR_OPEN",
+        product: { name: "TinyCal" },
+      } as any)
+      vi.mocked(prisma.timelineEvent.create).mockResolvedValue({} as any)
+
+      await updateTicketStatus("ticket-1", "PR_OPEN", {
+        actor: "dev",
+        summary: "PR opened",
+      })
+
+      // Only one DB update — no auto-transition
+      expect(prisma.ticket.update).toHaveBeenCalledTimes(1)
+    })
+  })
 })
 
 describe("appendTimelineEvent", () => {

--- a/src/lib/tickets.ts
+++ b/src/lib/tickets.ts
@@ -67,7 +67,19 @@ export async function createTicket(input: {
 export async function updateTicketStatus(
   ticketId: string,
   newStatus: TicketStatus,
-  options?: { actor?: string; summary?: string; eventType?: string; payload?: any }
+  options?: {
+    actor?: string
+    summary?: string
+    eventType?: string
+    payload?: any
+    /**
+     * When true, suppresses the email notification to the submitter.
+     * Used internally for auto-transitions that follow a user-visible status
+     * change (e.g. the CLOSED auto-transition after MERGED) so the submitter
+     * doesn't receive a redundant second email.
+     */
+    skipNotification?: boolean
+  }
 ) {
   const ticket = await prisma.ticket.update({
     where: { id: ticketId },
@@ -86,14 +98,31 @@ export async function updateTicketStatus(
     public: true,
   })
 
-  // Notify submitter
-  sendStatusUpdate(
-    ticket.submitterEmail,
-    ticket.publicId,
-    ticket.subject,
-    STATUS_CONFIG[newStatus].label,
-    summary
-  )
+  // Notify submitter (unless suppressed for internal auto-transitions)
+  if (!options?.skipNotification) {
+    sendStatusUpdate(
+      ticket.submitterEmail,
+      ticket.publicId,
+      ticket.subject,
+      STATUS_CONFIG[newStatus].label,
+      summary
+    )
+  }
+
+  // TD-0014: Auto-resolve ticket when it reaches MERGED state.
+  // Since deployment tracking is not yet implemented, MERGED is treated as
+  // the final resolution point. We silently transition to CLOSED so the
+  // ticket is definitively resolved without requiring a manual DEPLOYED →
+  // CLOSED progression. The MERGED notification above already informs the
+  // submitter that their fix has landed; no second email is sent.
+  if (newStatus === "MERGED") {
+    await updateTicketStatus(ticketId, "CLOSED", {
+      eventType: EVENT_TYPES.STATUS_CHANGED,
+      summary: "Ticket resolved: fix has been merged",
+      actor: options?.actor,
+      skipNotification: true,
+    })
+  }
 
   return ticket
 }


### PR DESCRIPTION
Closes #20

TD-0014: Makes `merged` the final resolved state for tickets, removing dependency on post-merge deployment tracking.

## Problem

The ticket lifecycle had 2 states after `MERGED`: `DEPLOYED` and `CLOSED`. Since deployment tracking is not yet implemented, tickets would stay stuck at `MERGED` indefinitely and never auto-resolve.

## Solution

When a ticket reaches `MERGED` (via the `pull_request closed+merged` GitHub webhook), it is automatically transitioned to `CLOSED` — silently, without a duplicate email. The `MERGED` notification already tells the submitter their fix has landed; the `CLOSED` transition is recorded in the timeline for auditability.

The `DEPLOYED` and `CLOSED` states are preserved in the schema for future use (e.g. when deployment tracking via Vercel webhooks is added), but they are no longer blocking resolution.

## Changes

- **`src/lib/tickets.ts`** — Added `skipNotification` option to `updateTicketStatus`; auto-transitions to `CLOSED` when `newStatus === "MERGED"`
- **`src/__tests__/lib/tickets.test.ts`** — 4 new tests: auto-close on MERGED, single email notification, timeline event recording, no-op for non-MERGED statuses

## Testing

All 99 tests pass:

```
Test Files  8 passed (8)
     Tests  99 passed (99)
```

New tests added under `TD-0014: auto-resolve on MERGED`:
- ✅ auto-transitions to CLOSED when status reaches MERGED
- ✅ sends exactly one email notification (for MERGED, not for the auto-close)
- ✅ records a timeline event for both MERGED and the auto-close CLOSED
- ✅ does NOT auto-close for non-MERGED status transitions