### PR TITLE
fix: resolve Vercel build failure — Prisma directUrl for Neon pooler (TD-0018)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,10 @@
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # Database (NeonDB)
-DATABASE_URL=postgresql://user:password@host/tinydesk?sslmode=require
+# Pooler URL — used at runtime (PgBouncer, efficient for serverless)
+DATABASE_URL=postgresql://user:password@ep-xxxx-pooler.region.aws.neon.tech/tinydesk?sslmode=require
+# Direct URL — used by Prisma migrations (bypasses pooler; advisory locks require direct connection)
+DIRECT_URL=postgresql://user:password@ep-xxxx.region.aws.neon.tech/tinydesk?sslmode=require
 
 # NextAuth
 AUTH_SECRET=your-auth-secret-here

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 enum Role {


### PR DESCRIPTION
## Problem
Vercel builds fail with `prisma migrate deploy` timing out (P1002) while trying to acquire a PostgreSQL advisory lock. The `DATABASE_URL` points to Neon's pooler endpoint, which uses PgBouncer in transaction mode — advisory locks are not supported in this mode.

## Root Cause
Prisma's migrate uses `pg_advisory_lock` internally. PgBouncer in transaction mode does not support session-level advisory locks, causing a 10s timeout.

## Fix
Added `directUrl = env("DIRECT_URL")` to `prisma/schema.prisma`. Prisma uses `directUrl` for migrations (bypassing the pooler) and `url` for runtime queries (via pooler for efficiency).

Also updated `.env.example` to document both `DATABASE_URL` and `DIRECT_URL` with clear comments.

## Required Action (Sze)
Add a `DIRECT_URL` environment variable to Vercel pointing to the **non-pooler** Neon connection string:
- Pooler URL (current DATABASE_URL): `postgresql://...@ep-dawn-king-adxq1grs-pooler.c-2.us-east-1.aws.neon.tech/neondb`
- Direct URL (DIRECT_URL): `postgresql://...@ep-dawn-king-adxq1grs.c-2.us-east-1.aws.neon.tech/neondb` (remove `-pooler` from hostname)

You can find both URLs in your Neon dashboard → Project → Connection Details → toggle between "Pooled" and "Direct" connections.

Closes #24