### PR TITLE
fix: post-deploy fixes for ticket submission and auth

### DIFF
--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -9,8 +9,12 @@ export async function POST(req: NextRequest) {
     const parsed = createTicketSchema.safeParse(body)
 
     if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors
+      const messages = Object.entries(fieldErrors)
+        .map(([field, errors]) => `${field}: ${errors?.join(", ")}`)
+        .join("; ")
       return NextResponse.json(
-        { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+        { error: messages || "Validation failed", details: fieldErrors },
         { status: 400 }
       )
     }

--- a/src/components/ticket-form.tsx
+++ b/src/components/ticket-form.tsx
@@ -14,6 +14,8 @@ interface TicketFormProps {
 
 const MAX_SCREENSHOTS = 3
 const MAX_FILE_SIZE = 5 * 1024 * 1024
+const MAX_SUBJECT_LENGTH = 200
+const MAX_BODY_LENGTH = 5000
 
 export function TicketForm({ products, onSuccess }: TicketFormProps) {
   const [loading, setLoading] = useState(false)
@@ -145,24 +147,40 @@ export function TicketForm({ products, onSuccess }: TicketFormProps) {
         onChange={(e) => setFormData({ ...formData, submitterName: e.target.value })}
       />
 
-      <Input
-        id="subject"
-        label="Subject"
-        required
-        placeholder="Brief summary of the issue"
-        value={formData.subject}
-        onChange={(e) => setFormData({ ...formData, subject: e.target.value })}
-      />
+      <div>
+        <Input
+          id="subject"
+          label="Subject"
+          required
+          maxLength={MAX_SUBJECT_LENGTH}
+          placeholder="Brief summary of the issue"
+          value={formData.subject}
+          onChange={(e) => setFormData({ ...formData, subject: e.target.value })}
+        />
+        {formData.subject.length > MAX_SUBJECT_LENGTH * 0.9 && (
+          <p className={`text-xs mt-1 ${formData.subject.length >= MAX_SUBJECT_LENGTH ? "text-red-600" : "text-gray-500"}`}>
+            {formData.subject.length}/{MAX_SUBJECT_LENGTH} characters
+          </p>
+        )}
+      </div>
 
-      <Textarea
-        id="body"
-        label="Description"
-        required
-        rows={5}
-        placeholder="Describe the issue in detail..."
-        value={formData.body}
-        onChange={(e) => setFormData({ ...formData, body: e.target.value })}
-      />
+      <div>
+        <Textarea
+          id="body"
+          label="Description"
+          required
+          rows={5}
+          maxLength={MAX_BODY_LENGTH}
+          placeholder="Describe the issue in detail..."
+          value={formData.body}
+          onChange={(e) => setFormData({ ...formData, body: e.target.value })}
+        />
+        {formData.body.length > MAX_BODY_LENGTH * 0.9 && (
+          <p className={`text-xs mt-1 ${formData.body.length >= MAX_BODY_LENGTH ? "text-red-600" : "text-gray-500"}`}>
+            {formData.body.length}/{MAX_BODY_LENGTH} characters
+          </p>
+        )}
+      </div>
 
       {/* Screenshots */}
       <div>

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -4,8 +4,8 @@ export const createTicketSchema = z.object({
   productSlug: z.string().min(1, "Product is required"),
   submitterEmail: z.string().email("Valid email is required"),
   submitterName: z.string().optional(),
-  subject: z.string().min(1, "Subject is required").max(200, "Subject too long"),
-  body: z.string().min(1, "Description is required").max(5000, "Description too long"),
+  subject: z.string().min(1, "Subject is required").max(200, "Subject must be 200 characters or fewer"),
+  body: z.string().min(1, "Description is required").max(5000, "Description must be 5,000 characters or fewer"),
   screenshots: z.array(z.string().url()).max(3, "Maximum 3 screenshots").optional(),
 })
 


### PR DESCRIPTION
## Summary
- Return descriptive, field-specific error messages when ticket submissions exceed character limits (subject: 200, body: 5,000) instead of a generic "Validation failed"
- Add client-side `maxLength` enforcement and character counters on the ticket form (visible at 90%+ capacity)
- Fix auth crash and public ticket page errors after TD-0008 merge (prior commit)

## Test plan
- [ ] Submit a ticket with a subject > 200 characters — verify a clear error message is returned
- [ ] Submit a ticket with a body > 5,000 characters — verify a clear error message is returned
- [ ] Verify character counter appears when nearing the limit and turns red at max
- [ ] Verify normal ticket submission still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)