### PR TITLE
feat: add agent integration info section to home page [TD-0028]

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { ArrowRight, Eye, GitBranch, Ticket, Zap } from "lucide-react"
+import { ArrowRight, Eye, GitBranch, Ticket, Zap, Bot, PackagePlus, Send, Search } from "lucide-react"
 
 export default function LandingPage() {
   return (
@@ -11,6 +11,9 @@ export default function LandingPage() {
             Tiny<span className="text-gray-900">Desk</span>
           </Link>
           <div className="flex items-center gap-4">
+            <Link href="#agent-integration" className="text-sm text-gray-600 hover:text-gray-900">
+              Agent API
+            </Link>
             <Link href="/login" className="text-sm text-gray-600 hover:text-gray-900">
               Admin Login
             </Link>
@@ -38,6 +41,12 @@ export default function LandingPage() {
           >
             Admin Dashboard <ArrowRight className="w-5 h-5" />
           </Link>
+          <Link
+            href="#agent-integration"
+            className="border border-gray-300 text-gray-700 px-8 py-3.5 rounded-lg text-lg font-medium hover:border-emerald-600 hover:text-emerald-600 transition flex items-center gap-2"
+          >
+            <Bot className="w-5 h-5" /> Agent API
+          </Link>
         </div>
       </section>
 
@@ -60,6 +69,152 @@ export default function LandingPage() {
                 <p className="text-gray-600 text-sm">{item.desc}</p>
               </div>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Agent Integration */}
+      <section id="agent-integration" className="py-20">
+        <div className="max-w-6xl mx-auto px-6">
+          {/* Header */}
+          <div className="text-center mb-14">
+            <div className="inline-flex items-center gap-2 bg-violet-50 text-violet-700 text-sm px-4 py-1.5 rounded-full mb-4">
+              <Bot className="w-4 h-4" /> Agent Integration
+            </div>
+            <h2 className="text-3xl font-bold text-gray-900 mb-4">Integrate your product with TinyDesk</h2>
+            <p className="text-gray-600 max-w-2xl mx-auto">
+              AI agents and automated systems can submit and track support tickets programmatically.
+              Follow these three steps to get your product connected.
+            </p>
+          </div>
+
+          {/* Steps */}
+          <div className="grid md:grid-cols-3 gap-8 mb-14">
+            {/* Step 1 */}
+            <div className="bg-white rounded-xl border p-6">
+              <div className="w-10 h-10 bg-violet-100 text-violet-700 rounded-lg flex items-center justify-center mb-4">
+                <PackagePlus className="w-5 h-5" />
+              </div>
+              <div className="text-xs font-semibold text-violet-600 uppercase tracking-wide mb-1">Step 1</div>
+              <h3 className="text-lg font-semibold mb-2">Register your product</h3>
+              <p className="text-gray-600 text-sm mb-4">
+                A TinyDesk admin registers your product via the dashboard and provides you with a unique{" "}
+                <code className="bg-gray-100 text-gray-800 px-1.5 py-0.5 rounded text-xs font-mono">productSlug</code>.
+                This slug identifies your product in every API call.
+              </p>
+              <div className="bg-gray-50 rounded-lg p-3 text-xs font-mono text-gray-700">
+                <div className="text-gray-400 mb-1"># Example product slug</div>
+                <span className="text-violet-600">&quot;productSlug&quot;</span>: <span className="text-emerald-600">&quot;my-saas-app&quot;</span>
+              </div>
+            </div>
+
+            {/* Step 2 */}
+            <div className="bg-white rounded-xl border p-6">
+              <div className="w-10 h-10 bg-emerald-100 text-emerald-700 rounded-lg flex items-center justify-center mb-4">
+                <Send className="w-5 h-5" />
+              </div>
+              <div className="text-xs font-semibold text-emerald-600 uppercase tracking-wide mb-1">Step 2</div>
+              <h3 className="text-lg font-semibold mb-2">Submit a ticket</h3>
+              <p className="text-gray-600 text-sm mb-4">
+                POST to the tickets endpoint with your product slug, submitter details, and issue description.
+                The response includes a <code className="bg-gray-100 text-gray-800 px-1.5 py-0.5 rounded text-xs font-mono">publicId</code> for tracking.
+              </p>
+              <div className="bg-gray-900 rounded-lg p-3 text-xs font-mono text-gray-100 space-y-0.5">
+                <div><span className="text-yellow-400">POST</span> <span className="text-gray-300">/api/tickets</span></div>
+                <div className="text-gray-500">Content-Type: application/json</div>
+              </div>
+            </div>
+
+            {/* Step 3 */}
+            <div className="bg-white rounded-xl border p-6">
+              <div className="w-10 h-10 bg-blue-100 text-blue-700 rounded-lg flex items-center justify-center mb-4">
+                <Search className="w-5 h-5" />
+              </div>
+              <div className="text-xs font-semibold text-blue-600 uppercase tracking-wide mb-1">Step 3</div>
+              <h3 className="text-lg font-semibold mb-2">Track the ticket</h3>
+              <p className="text-gray-600 text-sm mb-4">
+                Use the returned <code className="bg-gray-100 text-gray-800 px-1.5 py-0.5 rounded text-xs font-mono">publicId</code> to
+                poll ticket status and view the full 8-stage pipeline progress at any time.
+              </p>
+              <div className="bg-gray-900 rounded-lg p-3 text-xs font-mono text-gray-100 space-y-0.5">
+                <div><span className="text-green-400">GET</span> <span className="text-gray-300">/api/tickets/<span className="text-blue-300">:publicId</span></span></div>
+                <div className="text-gray-500">No auth required</div>
+              </div>
+            </div>
+          </div>
+
+          {/* API Reference */}
+          <div className="bg-gray-900 rounded-2xl overflow-hidden">
+            <div className="flex items-center gap-3 px-6 py-4 border-b border-gray-700">
+              <div className="flex gap-1.5">
+                <div className="w-3 h-3 rounded-full bg-red-500" />
+                <div className="w-3 h-3 rounded-full bg-yellow-500" />
+                <div className="w-3 h-3 rounded-full bg-green-500" />
+              </div>
+              <span className="text-gray-400 text-sm font-mono">POST /api/tickets — example request</span>
+            </div>
+            <div className="p-6 grid md:grid-cols-2 gap-6 text-sm font-mono">
+              {/* Request */}
+              <div>
+                <div className="text-gray-500 text-xs uppercase tracking-wide mb-3">Request body</div>
+                <pre className="text-gray-100 leading-6 whitespace-pre">{`{
+  "productSlug": "my-saas-app",
+  "submitterEmail": "agent@example.com",
+  "submitterName": "AI Agent v2",
+  "subject": "Login button unresponsive on Safari",
+  "body": "Reproducible steps:\\n1. Open Safari 17\\n2. Navigate to /login\\n3. Click Sign In\\n\\nExpected: form submits\\nActual: nothing happens",
+  "screenshots": [
+    "https://cdn.example.com/bug-01.png"
+  ]
+}`}</pre>
+                <div className="mt-4 space-y-1.5 text-xs">
+                  <div className="flex gap-2">
+                    <span className="text-red-400">required</span>
+                    <span className="text-gray-400">productSlug, submitterEmail, subject, body</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <span className="text-gray-500">optional</span>
+                    <span className="text-gray-400">submitterName, screenshots (max 3 URLs)</span>
+                  </div>
+                </div>
+              </div>
+              {/* Response */}
+              <div>
+                <div className="text-gray-500 text-xs uppercase tracking-wide mb-3">Response <span className="text-emerald-400">201 Created</span></div>
+                <pre className="text-gray-100 leading-6 whitespace-pre">{`{
+  "publicId": "TK-00042",
+  "status": "RECEIVED",
+  "createdAt": "2026-03-24T08:00:00.000Z"
+}`}</pre>
+                <div className="mt-4 space-y-1.5 text-xs text-gray-400">
+                  <div>• <span className="text-blue-300">publicId</span> — use this to track progress</div>
+                  <div>• <span className="text-blue-300">status</span> — initial status is always <span className="text-emerald-400">RECEIVED</span></div>
+                  <div>• Returns <span className="text-red-400">404</span> if productSlug is not registered</div>
+                  <div>• Returns <span className="text-red-400">400</span> with field errors on validation failure</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Status values */}
+          <div className="mt-8 bg-white rounded-xl border p-6">
+            <h3 className="font-semibold mb-4 text-gray-900">Ticket status values</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              {[
+                { status: "RECEIVED", color: "bg-gray-100 text-gray-700" },
+                { status: "ISSUE_CREATED", color: "bg-blue-50 text-blue-700" },
+                { status: "FIX_IN_PROGRESS", color: "bg-yellow-50 text-yellow-700" },
+                { status: "PR_OPEN", color: "bg-orange-50 text-orange-700" },
+                { status: "CHANGES_REQUESTED", color: "bg-red-50 text-red-700" },
+                { status: "MERGED", color: "bg-violet-50 text-violet-700" },
+                { status: "DEPLOYED", color: "bg-emerald-50 text-emerald-700" },
+                { status: "CLOSED", color: "bg-gray-100 text-gray-500" },
+              ].map(({ status, color }) => (
+                <div key={status} className={`rounded-lg px-3 py-2 text-xs font-mono font-medium ${color}`}>
+                  {status}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Adds an **Agent Integration** section to the TinyDesk home page so that AI agents and automated systems know how to register a product and submit tickets programmatically.

Closes #29

---

## What was added

### `src/app/page.tsx`

**Navigation:**
- Added an `Agent API` link in the nav bar (anchors to `#agent-integration`)
- Added a secondary CTA button in the Hero section linking to the same anchor

**New section — Agent Integration (`#agent-integration`):**

1. **Three-step guide** (card grid):
   - Step 1 — Register your product: explains that an admin assigns a `productSlug` via the dashboard
   - Step 2 — Submit a ticket: `POST /api/tickets` with endpoint hint
   - Step 3 — Track the ticket: `GET /api/tickets/:publicId` — no auth required

2. **API reference panel** (dark code block):
   - Full example request body with all fields (required + optional)
   - Example 201 response with `publicId`, `status`, `createdAt`
   - Inline notes on error cases (400 validation, 404 unknown product)

3. **Status value reference** — all 8 pipeline statuses displayed as colour-coded pills

---

## Design decisions

- Used violet accent for the Agent section to visually distinguish it from the main emerald theme while staying complementary
- No new dependencies — reuses existing Tailwind, lucide-react, and Next.js Link
- Kept product registration as an admin-gated action (existing behaviour) and surfaces it as "contact admin to get a slug" rather than exposing an unauthenticated registration endpoint
- All API details are accurate to the current `src/lib/validators.ts` schema

---

*Implemented by alpha-2 — Overnight Software Factory*