### PR TITLE
Fix regular users unable to submit support tickets

### DIFF
--- a/src/__tests__/api/products-list.test.ts
+++ b/src/__tests__/api/products-list.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    product: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+vi.mock("@/lib/auth", () => ({
+  requireDashboardAccess: vi.fn(),
+}))
+
+import prisma from "@/lib/prisma"
+import { requireDashboardAccess } from "@/lib/auth"
+import { GET } from "@/app/api/dashboard/products/list/route"
+
+const allProducts = [
+  { id: "prod-1", name: "TinyCal", slug: "tinycal" },
+  { id: "prod-2", name: "TinyDesk", slug: "tinydesk" },
+]
+
+describe("GET /api/dashboard/products/list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.product.findMany).mockResolvedValue(allProducts as never)
+  })
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(requireDashboardAccess).mockResolvedValue(null)
+
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it("returns all products for admin users", async () => {
+    vi.mocked(requireDashboardAccess).mockResolvedValue({
+      user: { id: "u1", email: "admin@example.com" } as never,
+      ownedProductIds: [],
+      isAdmin: true,
+      isProductOwner: false,
+    })
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+
+    const data = await res.json()
+    expect(data).toHaveLength(2)
+    expect(prisma.product.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: {} })
+    )
+  })
+
+  it("returns all products for product owners", async () => {
+    vi.mocked(requireDashboardAccess).mockResolvedValue({
+      user: { id: "u2", email: "owner@example.com" } as never,
+      ownedProductIds: ["prod-1"],
+      isAdmin: false,
+      isProductOwner: true,
+    })
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+
+    const data = await res.json()
+    expect(data).toHaveLength(2)
+    expect(prisma.product.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: {} })
+    )
+  })
+
+  it("returns all products for regular users (not just owned)", async () => {
+    vi.mocked(requireDashboardAccess).mockResolvedValue({
+      user: { id: "u3", email: "viewer@example.com" } as never,
+      ownedProductIds: [],
+      isAdmin: false,
+      isProductOwner: false,
+    })
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+
+    const data = await res.json()
+    expect(data).toHaveLength(2)
+    // Key assertion: regular users get an unfiltered query, not { id: { in: [] } }
+    expect(prisma.product.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: {} })
+    )
+  })
+})

--- a/src/app/api/dashboard/products/list/route.ts
+++ b/src/app/api/dashboard/products/list/route.ts
@@ -4,7 +4,8 @@ import { requireDashboardAccess } from "@/lib/auth"
 
 /**
  * Returns a lightweight list of products for the ticket submission form.
- * Admins see all products; product owners see their owned products.
+ * All authenticated users can see all products so they can submit tickets
+ * against any product.
  */
 export async function GET() {
   const access = await requireDashboardAccess()
@@ -12,9 +13,7 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 
-  const where = access.isAdmin
-    ? {}
-    : { id: { in: access.ownedProductIds } }
+  const where = {}
 
   try {
     const products = await prisma.product.findMany({


### PR DESCRIPTION
## Summary
- The `/api/dashboard/products/list` endpoint filtered products by ownership, returning an empty list for regular users (VIEWER role, no product ownership). This meant they saw "No projects available" and could not submit tickets.
- Fixed by returning all products for all authenticated users in the submission dropdown.
- Added tests covering all three role cases (admin, product owner, regular user).
- Ticket list visibility is unchanged — regular users still only see tickets they submitted.

Closes #46

## Test plan
- [x] All 163 existing tests pass
- [x] New `products-list.test.ts` covers admin, product owner, and regular user cases
- [ ] Manual: log in as a VIEWER user → Submit Ticket page should show all products in the dropdown
- [ ] Manual: verify VIEWER user's Tickets page still only shows their own tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)